### PR TITLE
added authentication ETE2-31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'esi'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()
@@ -19,7 +19,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'io.jsonwebtoken:jjwt:0.6.0'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.jsonwebtoken:jjwt:0.6.0'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/esi/backend/controller/AuthController.java
+++ b/src/main/java/esi/backend/controller/AuthController.java
@@ -1,0 +1,125 @@
+package esi.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+import esi.backend.model.ERole;
+import esi.backend.model.Role;
+import esi.backend.model.User;
+import esi.backend.payload.request.LoginRequest;
+import esi.backend.payload.request.SignupRequest;
+import esi.backend.payload.response.JwtResponse;
+import esi.backend.payload.response.MessageResponse;
+import esi.backend.repository.RoleRepository;
+import esi.backend.repository.UserRepository;
+import esi.backend.security.jwt.JwtUtils;
+import esi.backend.security.service.UserDetailsImpl;
+
+import javax.validation.Valid;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+    @Autowired
+    AuthenticationManager authenticationManager;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    @Autowired
+    PasswordEncoder encoder;
+
+    @Autowired
+    JwtUtils jwtUtils;
+
+    @PostMapping("/signin")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequest.getUsername(), loginRequest.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String jwt = jwtUtils.generateJwtToken(authentication);
+
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        List<String> roles = userDetails.getAuthorities().stream()
+                .map(item -> item.getAuthority())
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(new JwtResponse(jwt,
+                userDetails.getId(),
+                userDetails.getUsername(),
+                userDetails.getEmail(),
+                roles));
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
+        if (userRepository.existsByUsername(signUpRequest.getUsername())) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(new MessageResponse("Error: Username is already taken!"));
+        }
+
+        if (userRepository.existsByEmail(signUpRequest.getEmail())) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(new MessageResponse("Error: Email is already in use!"));
+        }
+
+        // Create new user's account
+        User user = new User(signUpRequest.getUsername(),
+                signUpRequest.getEmail(),
+                encoder.encode(signUpRequest.getPassword()));
+
+        Set<String> strRoles = signUpRequest.getRole();
+        Set<Role> roles = new HashSet<>();
+
+        if (strRoles == null) {
+            Role customerRole = roleRepository.findByName(ERole.ROLE_CUSTOMER)
+                    .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+            roles.add(customerRole);
+        } else {
+            strRoles.forEach(role -> {
+                switch (role) {
+                    case "manager":
+                        Role managerRole = roleRepository.findByName(ERole.ROLE_MANAGER)
+                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                        roles.add(managerRole);
+
+                        break;
+
+                    //                    case "admin":
+//                        Role adminRole = roleRepository.findByName(ERole.ROLE_ADMIN)
+//                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+//                        roles.add(adminRole);
+//
+//                        break;
+                    default:
+                        Role customerRole = roleRepository.findByName(ERole.ROLE_CUSTOMER)
+                                .orElseThrow(() -> new RuntimeException("Error: Role is not found."));
+                        roles.add(customerRole);
+                }
+            });
+        }
+
+        user.setRoles(roles);
+        userRepository.save(user);
+
+        return ResponseEntity.ok(new MessageResponse("User registered successfully!"));
+    }
+}
+

--- a/src/main/java/esi/backend/controller/CarController.java
+++ b/src/main/java/esi/backend/controller/CarController.java
@@ -1,13 +1,15 @@
 package esi.backend.controller;
 import esi.backend.model.Car;
 import esi.backend.service.CarService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-@CrossOrigin(origins = "http://localhost:8081")
+//@CrossOrigin(origins = "http://localhost:8081")
+@CrossOrigin(origins = "*", maxAge = 3600)
 @RestController
 @RequestMapping("/api")
 public class CarController {
@@ -23,23 +25,26 @@ public class CarController {
         return carService.getAllCars();
     }
 
-    @RequestMapping("/cars/{id}")
-    public Optional<Car> getCar(@PathVariable UUID id) {
-        return carService.getCar(id);
+    @GetMapping("/cars/{carId}")
+    public Optional<Car> getCar(@PathVariable UUID carId) {
+        return carService.getCar(carId);
     }
 
     @PostMapping("/cars")
+    @PreAuthorize("hasRole('MANAGER')")
     public void addCar(@RequestBody Car car) {
         carService.addCar(car);
     }
 
-    @RequestMapping(method = RequestMethod.PUT, value = "/cars/{id}")
-    public void updateCar(@RequestBody Car car, @PathVariable UUID id) {
-        carService.updateCar(id, car);
+    @RequestMapping(method = RequestMethod.PUT, value = "/cars/{carId}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public void updateCar(@RequestBody Car car, @PathVariable UUID carId) {
+        carService.updateCar(carId, car);
     }
 
-    @RequestMapping(method = RequestMethod.DELETE, value = "/cars/{id}")
-    public void deleteCar(@PathVariable UUID id) {
-        carService.deleteCar(id);
+    @RequestMapping(method = RequestMethod.DELETE, value = "/cars/{carId}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public void deleteCar(@PathVariable UUID carId) {
+        carService.deleteCar(carId);
     }
 }

--- a/src/main/java/esi/backend/controller/RentalController.java
+++ b/src/main/java/esi/backend/controller/RentalController.java
@@ -20,12 +20,21 @@ public class RentalController {
         this.rentalService = rentalService;
     }
 
+
+    @RequestMapping("/rentals")
+    @PreAuthorize("hasRole('MANAGER')")
+    public List<Rental> getAllRentals() {
+        return rentalService.getAllRentals();
+    }
+
     @RequestMapping("/cars/{carId}/rentals")
+    @PreAuthorize("hasRole('MANAGER')")
     public List<Rental> getAllRentals(@PathVariable UUID carId) {
         return rentalService.getAllRentals(carId);
     }
 
     @RequestMapping("/cars/{carId}/rentals/{rentalId}")
+    @PreAuthorize("hasRole('MANAGER')")
     public Optional<Rental> getRental(@PathVariable UUID rentalId) {
         return rentalService.getRental(rentalId);
     }
@@ -50,6 +59,5 @@ public class RentalController {
     public void deleteRental(@PathVariable UUID rentalId) {
         rentalService.deleteRental(rentalId);
     }
-
 
 }

--- a/src/main/java/esi/backend/controller/RentalController.java
+++ b/src/main/java/esi/backend/controller/RentalController.java
@@ -25,7 +25,7 @@ public class RentalController {
         return rentalService.getAllRentals(carId);
     }
 
-    @RequestMapping("/cars/rentals/{rentalId}")
+    @RequestMapping("/cars/{carId}/rentals/{rentalId}")
     public Optional<Rental> getRental(@PathVariable UUID rentalId) {
         return rentalService.getRental(rentalId);
     }
@@ -45,7 +45,7 @@ public class RentalController {
         rentalService.updateRental(rental);
     }
 
-    @RequestMapping(method = RequestMethod.DELETE, value = "/cars/rentals/{rentalId}")
+    @RequestMapping(method = RequestMethod.DELETE, value = "/cars/{carId}/rentals/{rentalId}")
     @PreAuthorize("hasRole('MANAGER')")
     public void deleteRental(@PathVariable UUID rentalId) {
         rentalService.deleteRental(rentalId);

--- a/src/main/java/esi/backend/controller/RentalController.java
+++ b/src/main/java/esi/backend/controller/RentalController.java
@@ -3,6 +3,7 @@ package esi.backend.controller;
 import esi.backend.model.Car;
 import esi.backend.model.Rental;
 import esi.backend.service.RentalService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Optional;
@@ -24,28 +25,30 @@ public class RentalController {
         return rentalService.getAllRentals(carId);
     }
 
-    @RequestMapping("/cars/rentals/{id}")
-    public Optional<Rental> getRental(@PathVariable UUID id) {
-        return rentalService.getRental(id);
+    @RequestMapping("/cars/rentals/{rentalId}")
+    public Optional<Rental> getRental(@PathVariable UUID rentalId) {
+        return rentalService.getRental(rentalId);
     }
 
     @RequestMapping(method = RequestMethod.POST, value = "/cars/{carId}/rentals")
+    @PreAuthorize("hasRole('MANAGER')")
     public void addRental(@RequestBody Rental rental, @PathVariable UUID carId) {
         rental.setCar(new Car());
         rentalService.addRental(rental);
     }
 
-    @RequestMapping(method = RequestMethod.PUT, value = "/cars/{carId}/rentals/{id}")
+    @RequestMapping(method = RequestMethod.PUT, value = "/cars/{carId}/rentals/{rentalId}")
+    @PreAuthorize("hasRole('MANAGER')")
     public void updateRental(@RequestBody Rental rental, @PathVariable UUID
-            carId, @PathVariable UUID id) {
+            carId, @PathVariable UUID rentalId) {
         rental.setCar(new Car());
         rentalService.updateRental(rental);
     }
 
-    @RequestMapping(method = RequestMethod.DELETE, value
-            = "/cars/rentals/{id}")
-    public void deleteRental(@PathVariable UUID id) {
-        rentalService.deleteRental(id);
+    @RequestMapping(method = RequestMethod.DELETE, value = "/cars/rentals/{rentalId}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public void deleteRental(@PathVariable UUID rentalId) {
+        rentalService.deleteRental(rentalId);
     }
 
 

--- a/src/main/java/esi/backend/controller/TestController.java
+++ b/src/main/java/esi/backend/controller/TestController.java
@@ -1,0 +1,30 @@
+package esi.backend.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin(origins = "*", maxAge = 3600)
+@RestController
+@RequestMapping("/api/test")
+public class TestController {
+  @GetMapping("/all")
+  public String allAccess() {
+    return "Public Content.";
+  }
+
+  @GetMapping("/user")
+  @PreAuthorize("hasRole('CUSTOMER') or hasRole('MANAGER')")
+  public String userAccess() {
+    return "User Content.";
+  }
+
+  @GetMapping("/manager")
+  @PreAuthorize("hasRole('MANAGER')")
+  public String moderatorAccess() {
+    return "Manager Board.";
+  }
+
+}

--- a/src/main/java/esi/backend/model/ERole.java
+++ b/src/main/java/esi/backend/model/ERole.java
@@ -1,0 +1,7 @@
+package esi.backend.model;
+
+public enum ERole {
+    ROLE_CUSTOMER,
+    ROLE_MANAGER
+    // ROLE_ADMIN
+}

--- a/src/main/java/esi/backend/model/Role.java
+++ b/src/main/java/esi/backend/model/Role.java
@@ -1,0 +1,31 @@
+package esi.backend.model;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "roles")
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ERole name;
+    public Role() {
+    }
+    public Role(ERole name) {
+        this.name = name;
+    }
+    public Integer getId() {
+        return id;
+    }
+    public void setId(Integer id) {
+        this.id = id;
+    }
+    public ERole getName() {
+        return name;
+    }
+    public void setName(ERole name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/esi/backend/model/User.java
+++ b/src/main/java/esi/backend/model/User.java
@@ -1,0 +1,72 @@
+package esi.backend.model;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "username"),
+                @UniqueConstraint(columnNames = "email")
+        })
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotBlank
+    @Size(max = 20)
+    private String username;
+    @NotBlank
+    @Size(max = 50)
+    @Email
+    private String email;
+    @NotBlank
+    @Size(max = 120)
+    private String password;
+    @ManyToMany(fetch = FetchType.LAZY,cascade = CascadeType.ALL)
+    @JoinTable(name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Set<Role> roles = new HashSet<>();
+    public User() {
+    }
+    public User(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    public Set<Role> getRoles() {
+        return roles;
+    }
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
+    }
+}

--- a/src/main/java/esi/backend/payload/request/LoginRequest.java
+++ b/src/main/java/esi/backend/payload/request/LoginRequest.java
@@ -1,0 +1,27 @@
+package esi.backend.payload.request;
+
+import javax.validation.constraints.NotBlank;
+
+public class LoginRequest {
+	@NotBlank
+  private String username;
+
+	@NotBlank
+	private String password;
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/esi/backend/payload/request/SignupRequest.java
+++ b/src/main/java/esi/backend/payload/request/SignupRequest.java
@@ -1,0 +1,55 @@
+package esi.backend.payload.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.Set;
+
+public class SignupRequest {
+  @NotBlank
+  @Size(min = 3, max = 20)
+  private String username;
+
+  @NotBlank
+  @Size(max = 50)
+  @Email
+  private String email;
+
+  private Set<String> role;
+
+  @NotBlank
+  @Size(min = 6, max = 40)
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public Set<String> getRole() {
+    return this.role;
+  }
+
+  public void setRole(Set<String> role) {
+    this.role = role;
+  }
+}

--- a/src/main/java/esi/backend/payload/response/JwtResponse.java
+++ b/src/main/java/esi/backend/payload/response/JwtResponse.java
@@ -1,0 +1,64 @@
+package esi.backend.payload.response;
+
+import java.util.List;
+
+public class JwtResponse {
+  private String token;
+  private String type = "Bearer";
+  private Long id;
+  private String username;
+  private String email;
+  private List<String> roles;
+
+  public JwtResponse(String accessToken, Long id, String username, String email, List<String> roles) {
+    this.token = accessToken;
+    this.id = id;
+    this.username = username;
+    this.email = email;
+    this.roles = roles;
+  }
+
+  public String getAccessToken() {
+    return token;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.token = accessToken;
+  }
+
+  public String getTokenType() {
+    return type;
+  }
+
+  public void setTokenType(String tokenType) {
+    this.type = tokenType;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public List<String> getRoles() {
+    return roles;
+  }
+}

--- a/src/main/java/esi/backend/payload/response/MessageResponse.java
+++ b/src/main/java/esi/backend/payload/response/MessageResponse.java
@@ -1,0 +1,17 @@
+package esi.backend.payload.response;
+
+public class MessageResponse {
+  private String message;
+
+  public MessageResponse(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/src/main/java/esi/backend/repository/RoleRepository.java
+++ b/src/main/java/esi/backend/repository/RoleRepository.java
@@ -1,0 +1,13 @@
+package esi.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import esi.backend.model.ERole;
+import esi.backend.model.Role;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(ERole name);
+}

--- a/src/main/java/esi/backend/repository/UserRepository.java
+++ b/src/main/java/esi/backend/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package esi.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import esi.backend.model.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    Boolean existsByUsername(String username);
+    Boolean existsByEmail(String email);
+}

--- a/src/main/java/esi/backend/security/WebSecurityConfig.java
+++ b/src/main/java/esi/backend/security/WebSecurityConfig.java
@@ -1,0 +1,65 @@
+package esi.backend.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import esi.backend.security.jwt.AuthEntryPointJwt;
+import esi.backend.security.jwt.AuthTokenFilter;
+import esi.backend.security.service.UserDetailsServiceImpl;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(
+        // securedEnabled = true,
+        // jsr250Enabled = true,
+        prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Autowired
+    UserDetailsServiceImpl userDetailsService;
+
+    @Autowired
+    private AuthEntryPointJwt unauthorizedHandler;
+
+    @Bean
+    public AuthTokenFilter authenticationJwtTokenFilter() {
+        return new AuthTokenFilter();
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
+        authenticationManagerBuilder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors().and().csrf().disable()
+                .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+                .authorizeRequests().antMatchers("/api/auth/**").permitAll()
+                .antMatchers("/api/test/**").permitAll()
+                .anyRequest().authenticated();
+
+        http.addFilterBefore(authenticationJwtTokenFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/esi/backend/security/WebSecurityConfig.java
+++ b/src/main/java/esi/backend/security/WebSecurityConfig.java
@@ -57,6 +57,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests().antMatchers("/api/auth/**").permitAll()
+                .antMatchers("/api/cars/**").permitAll()
+                .antMatchers("/api/rentals/**").permitAll()
                 .antMatchers("/api/test/**").permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/esi/backend/security/jwt/AuthEntryPointJwt.java
+++ b/src/main/java/esi/backend/security/jwt/AuthEntryPointJwt.java
@@ -1,0 +1,41 @@
+package esi.backend.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class AuthEntryPointJwt implements AuthenticationEntryPoint {
+
+  private static final Logger logger = LoggerFactory.getLogger(AuthEntryPointJwt.class);
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+      throws IOException, ServletException {
+    logger.error("Unauthorized error: {}", authException.getMessage());
+
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    final Map<String, Object> body = new HashMap<>();
+    body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+    body.put("error", "Unauthorized");
+    body.put("message", authException.getMessage());
+    body.put("path", request.getServletPath());
+
+    final ObjectMapper mapper = new ObjectMapper();
+    mapper.writeValue(response.getOutputStream(), body);
+  }
+
+}

--- a/src/main/java/esi/backend/security/jwt/AuthTokenFilter.java
+++ b/src/main/java/esi/backend/security/jwt/AuthTokenFilter.java
@@ -1,0 +1,63 @@
+package esi.backend.security.jwt;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import esi.backend.security.service.UserDetailsServiceImpl;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthTokenFilter extends OncePerRequestFilter {
+  @Autowired
+  private JwtUtils jwtUtils;
+
+  @Autowired
+  private UserDetailsServiceImpl userDetailsService;
+
+  private static final Logger logger = LoggerFactory.getLogger(AuthTokenFilter.class);
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      String jwt = parseJwt(request);
+      if (jwt != null && jwtUtils.validateJwtToken(jwt)) {
+        String username = jwtUtils.getUserNameFromJwtToken(jwt);
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
+    } catch (Exception e) {
+      logger.error("Cannot set user authentication: {}", e);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String parseJwt(HttpServletRequest request) {
+    String headerAuth = request.getHeader("Authorization");
+
+    if (StringUtils.hasText(headerAuth) && headerAuth.startsWith("Bearer ")) {
+      return headerAuth.substring(7, headerAuth.length());
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/esi/backend/security/jwt/JwtUtils.java
+++ b/src/main/java/esi/backend/security/jwt/JwtUtils.java
@@ -1,0 +1,57 @@
+package esi.backend.security.jwt;
+
+import io.jsonwebtoken.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import esi.backend.security.service.UserDetailsImpl;
+
+import java.util.Date;
+
+@Component
+public class JwtUtils {
+  private static final Logger logger = LoggerFactory.getLogger(JwtUtils.class);
+
+  @Value("${backend.app.jwtSecret}")
+  private String jwtSecret;
+
+  @Value("${backend.app.jwtExpirationMs}")
+  private int jwtExpirationMs;
+
+  public String generateJwtToken(Authentication authentication) {
+
+    UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
+
+    return Jwts.builder()
+        .setSubject((userPrincipal.getUsername()))
+        .setIssuedAt(new Date())
+        .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+        .signWith(SignatureAlgorithm.HS512, jwtSecret)
+        .compact();
+  }
+
+  public String getUserNameFromJwtToken(String token) {
+    return Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody().getSubject();
+  }
+
+  public boolean validateJwtToken(String authToken) {
+    try {
+      Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(authToken);
+      return true;
+    } catch (SignatureException e) {
+      logger.error("Invalid JWT signature: {}", e.getMessage());
+    } catch (MalformedJwtException e) {
+      logger.error("Invalid JWT token: {}", e.getMessage());
+    } catch (ExpiredJwtException e) {
+      logger.error("JWT token is expired: {}", e.getMessage());
+    } catch (UnsupportedJwtException e) {
+      logger.error("JWT token is unsupported: {}", e.getMessage());
+    } catch (IllegalArgumentException e) {
+      logger.error("JWT claims string is empty: {}", e.getMessage());
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/esi/backend/security/service/UserDetailsImpl.java
+++ b/src/main/java/esi/backend/security/service/UserDetailsImpl.java
@@ -1,0 +1,102 @@
+package esi.backend.security.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import esi.backend.model.User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class UserDetailsImpl implements UserDetails {
+  private static final long serialVersionUID = 1L;
+
+  private Long id;
+
+  private String username;
+
+  private String email;
+
+  @JsonIgnore
+  private String password;
+
+  private Collection<? extends GrantedAuthority> authorities;
+
+  public UserDetailsImpl(Long id, String username, String email, String password,
+      Collection<? extends GrantedAuthority> authorities) {
+    this.id = id;
+    this.username = username;
+    this.email = email;
+    this.password = password;
+    this.authorities = authorities;
+  }
+
+  public static UserDetailsImpl build(User user) {
+    List<GrantedAuthority> authorities = user.getRoles().stream()
+        .map(role -> new SimpleGrantedAuthority(role.getName().name()))
+        .collect(Collectors.toList());
+
+    return new UserDetailsImpl(
+        user.getId(), 
+        user.getUsername(), 
+        user.getEmail(),
+        user.getPassword(), 
+        authorities);
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return authorities;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    UserDetailsImpl user = (UserDetailsImpl) o;
+    return Objects.equals(id, user.id);
+  }
+}

--- a/src/main/java/esi/backend/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/esi/backend/security/service/UserDetailsServiceImpl.java
@@ -1,0 +1,26 @@
+package esi.backend.security.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import esi.backend.model.User;
+import esi.backend.repository.UserRepository;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+  @Autowired
+  UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    User user = userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with username: " + username));
+
+    return esi.backend.security.service.UserDetailsImpl.build(user);
+  }
+
+}

--- a/src/main/java/esi/backend/service/RentalService.java
+++ b/src/main/java/esi/backend/service/RentalService.java
@@ -13,6 +13,10 @@ public class RentalService {
 
     private RentalRepository rentalRepository;
 
+    public List<Rental> getAllRentals(){
+        return (List<Rental>) rentalRepository.findAll();
+    }
+
     public List<Rental> getAllRentals(UUID carId) {
         return rentalRepository.findByCarId(carId);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,14 @@
-#spring.sql.init.mode=always
-#spring.sql.init.platform=postgres
+server.port=8081
+spring.sql.init.mode=always
+spring.sql.init.platform=postgres
 spring.datasource.url= jdbc:postgresql://localhost:5432/project
 spring.datasource.username= postgres
 spring.datasource.password= postgres
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation= true
 spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect
-# Hibernate ddl auto (create, create-drop, validate, update)
+# Hibernate=ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto= update
+# App Properties
+backend.app.jwtCookieName= backend
+backend.app.jwtSecret= backendSecretKey
+backend.app.jwtExpirationMs= 86400000

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,9 @@
-TRUNCATE cars,reservations RESTART IDENTITY;
+TRUNCATE cars,roles,users,rentals CASCADE;
 
 INSERT INTO cars (id,mark, model, nr_of_seats, transmission_type, fuel_type, daily_cost, year, licence_plate) VALUES
-    ('a81bc81b-dead-4e5d-abff-90865d1e13b1','Ford','Focus 1.6 Aut',5,'Automatic','Petrol',71,2002,'123 ABC'),
-    ('a81bc81b-dead-4e5d-abcf-90865d1e98r2','Mercedes-Benz','C 220 AMG',5,'Automatic','Diesel',50,2012,'456 DEF');
+     ('a81bc81b-dead-4e5d-abff-90865d1e13b1','Ford','Focus 1.6 Aut',5,'Automatic','Petrol',71,2002,'123 ABC'),
+     ('a81bc81b-dead-4e5d-abdd-90865d1e13b1','Mercedes-Benz','C 220 AMG',5,'Automatic','Diesel',50,2012,'456 DEF');
+
+INSERT INTO roles(id,name) VALUES
+(1,'ROLE_CUSTOMER'),
+(2,'ROLE_MANAGER');

--- a/src/test/java/esi/backend/BackendApplicationTests.java
+++ b/src/test/java/esi/backend/BackendApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class BackendNewApplicationTests {
+class BackendApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
The authentication requires one to be logged in as a customer or a manager to be able to access any content (which is not that much of an issue, but bear it in mind when trying to use Postman to test it). Creating, modifying and deleting cars or rentals can only be done while being logged in as a manager.

TestConrtoller is only there to offer examples on accessing restricted content.

The data.sql file resets the old values in the tables users, roles, cars and rentals, since truncate cannot be executed by resetting identity and cascade had to be used instead. It is recommended that new users are not created through data.sql file and are inserted into the database using Postman instead (because of password hashing and roles relation).